### PR TITLE
use variable for storage account name

### DIFF
--- a/roles/azure_infra/tasks/azure_deploy.yml
+++ b/roles/azure_infra/tasks/azure_deploy.yml
@@ -858,13 +858,10 @@
       version: latest
 
 # Registry 
-- set_fact: 
-    registry_storage_account: "{{ rg | regex_replace('-') }}"
-
 - name: Azure | Manage Registry Storage Account
   azure_rm_storageaccount:
     resource_group: "{{ rg }}"
-    name: "{{ rg | regex_replace('-') }}"
+    name: "{{ registry_storage_account }}"
     state: "{{ state }}"
     location: "{{ location }}"
     account_type: Standard_LRS


### PR DESCRIPTION
The variable registry_storage_account was already defined in vars.yml.example, but not used by the role.