### PR TITLE
lower ControlPersist timeout

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,5 +6,5 @@ forks          = 15
 log_path = ansible.log
 
 [ssh_connection]
-ssh_args = -C -o ControlMaster=auto -o ControlPersist=1200s
+ssh_args = -C -o ControlMaster=auto -o ControlPersist=120s
 pipelining = True

--- a/roles/azure_infra/files/ansible.cfg
+++ b/roles/azure_infra/files/ansible.cfg
@@ -6,5 +6,5 @@ forks          = 15
 log_path = ansible.log
 
 [ssh_connection]
-ssh_args = -C -o ControlMaster=auto -o ControlPersist=1200s
+ssh_args = -C -o ControlMaster=auto -o ControlPersist=120s
 pipelining = True


### PR DESCRIPTION
Lowering ControlPersist from 20 to 2 minutes has fixed the semi-random SSH connection errors that I got before when running the deploy.yml playbook. Reconnecting every two minutes should be acceptable from a performance point of view.