### PR TITLE
replace undefined variable with string

### DIFF
--- a/roles/azure_infra/templates/hosts.j2
+++ b/roles/azure_infra/templates/hosts.j2
@@ -45,7 +45,7 @@ openshift_master_cluster_method=native
 openshift_master_cluster_hostname={{ rg }}.{{ location }}.cloudapp.azure.com
 openshift_master_cluster_public_hostname={{ rg }}.{{ location }}.cloudapp.azure.com
 {% else %}
-openshift_master_cluster_hostname={{ groups['masters'][0] }}
+openshift_master_cluster_hostname=ocp-master-1
 openshift_master_cluster_public_hostname={{ master_lb_private_dns }}
 {% endif %}
 openshift_master_default_subdomain={{ router_lb_ip }}.nip.io


### PR DESCRIPTION
When someone runs deploy.yml for the first time, they won't have a "hosts" file in their directory, and groups['masters'][0] is undefined:

TASK [azure_infra : Azure | template ansible hosts] *****************************************************************************************************
Wednesday 11 July 2018  21:55:59 -0700 (0:00:00.041)       1:28:26.236 ******** 
fatal: [localhost]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'masters'"}

I don't see a way around this, except by hard-coding the value of openshift_master_cluster_hostname. That should be OK though, since the hostnames are generated automatically.