### PR TITLE
remove duplicate task

### DIFF
--- a/roles/azure_infra/tasks/azure_deploy.yml
+++ b/roles/azure_infra/tasks/azure_deploy.yml
@@ -1,8 +1,3 @@
-- name: Azure | Bastion copy files
-  copy:
-    src: ansible.cfg
-    dest: ansible.cfg
-
 - name: Azure | Manage Resource Group
   azure_rm_resourcegroup:
     state: "{{ state }}"


### PR DESCRIPTION
The removed task wasn't running on the bastion, but was overwriting the ansible.cfg file in the local Git directory. That file is managed Git, and should not be overwritten by the playbook.

We still have a task with the same name in bastion.yml that copies the file to the bastion.