### PR TITLE
change VM disk creation and references

### DIFF
--- a/roles/azure_infra/tasks/azure_deploy.yml
+++ b/roles/azure_infra/tasks/azure_deploy.yml
@@ -696,9 +696,14 @@
   when: bastion_private_ip is defined
 
 # Create VMs
-
+#
 # We use the CLI option "--no-wait" to create all VMs in parallel, and
 # then wait in an Ansible loop until all of them exist.
+
+# Data disks:
+# 32 GB Container Storage for emptydir, /var/lib/origin
+# 32 GB Docker VG
+# 32 GB ETCD
 - name: Azure | Schedule Master VM creation
   command: >
     az vm create
@@ -707,6 +712,7 @@
     --name ocp-master-{{ item }}
     --size {{ vm_size_master }}
     --storage-sku Standard_LRS
+    --data-disk-sizes 32 32 32
     --nics ocp-master-{{ item }}VMNic
     --image RedHat:RHEL:7-RAW:latest
     --admin-username {{ admin_user }}
@@ -716,6 +722,16 @@
     --no-wait
   loop: "{{ master_nodes }}" 
 
+- set_fact:
+    infra_cns_size: 512
+  when:
+    - deploy_cns | default(true) | bool
+    - deploy_cns_on_infra | default(false) | bool
+
+# Data disks:
+# 64 GB Container Storage for emptydir, /var/lib/origin
+# 32 GB Docker VG
+# 512 GB Gluster brick (optional)
 - name: Azure | Schedule Infra VM creation
   command: >
     az vm create
@@ -724,6 +740,7 @@
     --name ocp-infra-{{ item }}
     --size {{ vm_size_infra }}
     --storage-sku Standard_LRS
+    --data-disk-sizes 64 32 {{ infra_cns_size | default('') }}
     --nics ocp-infra-{{ item }}VMNic
     --image RedHat:RHEL:7-RAW:latest
     --admin-username {{ admin_user }}
@@ -733,6 +750,9 @@
     --no-wait
   loop: "{{ infra_nodes }}"
 
+# Data disks:
+# 64 GB Container Storage for emptydir, /var/lib/origin
+# 32 GB Docker VG
 - name: Azure | Schedule App VM creation
   command: >
     az vm create
@@ -741,6 +761,7 @@
     --name ocp-app-{{ item }}
     --size {{ vm_size_node }}
     --storage-sku Standard_LRS
+    --data-disk-sizes 64 32
     --nics ocp-app-{{ item }}VMNic
     --image RedHat:RHEL:7-RAW:latest
     --admin-username {{ admin_user }}
@@ -750,6 +771,10 @@
     --no-wait
   loop: "{{ app_nodes }}"
 
+# Data disks:
+# 64 GB Container Storage for emptydir, /var/lib/origin
+# 32 GB Docker VG
+# 512 GB Gluster brick
 - name: Azure | Schedule CNS VM creation
   command: >
     az vm create
@@ -758,6 +783,7 @@
     --name ocp-cns-{{ item }}
     --size {{ vm_size_cns }}
     --storage-sku Standard_LRS
+    --data-disk-sizes 64 32 512
     --nics ocp-cns-{{ item }}VMNic
     --image RedHat:RHEL:7-RAW:latest
     --admin-username {{ admin_user }}
@@ -792,41 +818,6 @@
   delay: 60
   until: vm_list.stdout_lines | map("regex_search", "ocp-master-[0-9]+") | select("string") | list | length == master_nodes | length
 
-# We create the disks separately because the "--data-disk-sizes"
-# option for "az vm create" sometimes associates the disks with the
-# wrong block device, even thought the LUN numbers in the Azure portal
-# look correct.
-
-# Container Storage for emptydir  /var/lib/origin /dev/sdc
-- name: Azure | Master node mount container managed disk
-  azure_rm_managed_disk:
-    name: "ocp-master-container-{{ item }}" 
-    location: "{{ location }}"
-    resource_group: "{{ rg }}"
-    disk_size_gb: 32 
-    managed_by: "ocp-master-{{ item }}"
-  loop: "{{ master_nodes }}"
-
-# Docker VG /dev/sdd
-- name: Azure | Master node mount docker managed disk
-  azure_rm_managed_disk:
-    name: "ocp-master-docker-{{ item }}" 
-    location: "{{ location }}"
-    resource_group: "{{ rg }}"
-    disk_size_gb: 32
-    managed_by: "ocp-master-{{ item }}"
-  loop: "{{ master_nodes }}"
-
-# ETCD /dev/sde
-- name: Azure | Master node mount ETCD managed disk
-  azure_rm_managed_disk:
-    name: "ocp-master-etcd-{{ item }}" 
-    location: "{{ location }}"
-    resource_group: "{{ rg }}"
-    disk_size_gb: 32
-    managed_by: "ocp-master-{{ item }}"
-  loop: "{{ master_nodes }}"
-
 # Infra VMs
 
 - name: Azure | Wait for infra VM creation
@@ -836,40 +827,6 @@
   delay: 60
   until: vm_list.stdout_lines | map("regex_search", "ocp-infra-[0-9]+") | select("string") | list | length == infra_nodes | length
 
-# Container Storage for emptydir  /var/lib/origin /dev/sdc
-- name: Azure | Infra node mount container managed disk
-  azure_rm_managed_disk:
-    name: "ocp-infra-container-{{ item }}" 
-    location: "{{ location }}"
-    resource_group: "{{ rg }}"
-    disk_size_gb: 64
-    managed_by: "ocp-infra-{{ item }}"
-  loop: "{{ infra_nodes }}"
-
-# Docker VG /dev/sdd
-- name: Azure | Infra node mount docker managed disk
-  azure_rm_managed_disk:
-    name: "ocp-infra-docker-{{ item }}" 
-    location: "{{ location }}"
-    resource_group: "{{ rg }}"
-    disk_size_gb: 32
-    managed_by: "ocp-infra-{{ item }}"
-  loop: "{{ infra_nodes }}"
-
-# Create managed Gluster brick when deploy_cns_on_infra
-# Bricks /dev/sde 
-- name: Azure | Infra CNS mount BRICK managed disk
-  azure_rm_managed_disk:
-    name: "ocp-cns-volume-{{ item }}" 
-    location: "{{ location }}"
-    resource_group: "{{ rg }}"
-    disk_size_gb: 512
-    managed_by: "ocp-infra-{{ item }}"
-  loop: "{{ infra_nodes }}"
-  when: 
-    - deploy_cns | default(true) | bool
-    - deploy_cns_on_infra | default(false) | bool
-
 - name: Azure | Wait for master VM creation
   command: az vm list -g "{{ rg }}" --query "[?provisioningState=='Succeeded'].name" -o tsv
   register: vm_list
@@ -877,25 +834,6 @@
   delay: 60
   until: vm_list.stdout_lines | map("regex_search", "ocp-app-[0-9]+") | select("string") | list | length == app_nodes | length
 
-# Container Storage for emptydir  /var/lib/origin /dev/sdc
-- name: Azure | App node mount container managed disk
-  azure_rm_managed_disk:
-    name: "ocp-app-container-{{ item }}" 
-    location: "{{ location }}"
-    resource_group: "{{ rg }}"
-    disk_size_gb: 64
-    managed_by: "ocp-app-{{ item }}"
-  loop: "{{ app_nodes }}"
-
-# Docker VG /dev/sdd
-- name: Azure | App node mount docker managed disk
-  azure_rm_managed_disk:
-    name: "ocp-app-docker-{{ item }}" 
-    location: "{{ location }}"
-    resource_group: "{{ rg }}"
-    disk_size_gb: 32
-    managed_by: "ocp-app-{{ item }}"
-  loop: "{{ app_nodes }}"
 
 # CNS VMs
 - block:
@@ -905,39 +843,6 @@
     retries: 30
     delay: 60
     until: vm_list.stdout_lines | map("regex_search", "ocp-cns-[0-9]+") | select("string") | list | length == cns_nodes | length
-
-  # Container Storage for emptydir  /var/lib/origin /dev/sdc
-  - name: Azure | CNS node mount container managed disk
-    azure_rm_managed_disk:
-      name: "ocp-cns-container-{{ item }}" 
-      location: "{{ location }}"
-      resource_group: "{{ rg }}"
-      disk_size_gb: 64
-      managed_by: "ocp-cns-{{ item  }}"
-    loop: "{{ cns_nodes }}"
-
-  # Docker VG /dev/sdd
-  - name: Azure | CNS node mount docker managed disk
-    azure_rm_managed_disk:
-      name: "ocp-cns-docker-{{ item }}" 
-      location: "{{ location }}"
-      resource_group: "{{ rg }}"
-      disk_size_gb: 32
-      managed_by: "ocp-cns-{{ item }}"
-    loop: "{{ cns_nodes }}"
-
-  # Bricks /dev/sde 
-  - name: Azure | CNS node mount BRICK managed disk
-    azure_rm_managed_disk:
-      name: "ocp-cns-volume-{{ item }}" 
-      location: "{{ location }}"
-      resource_group: "{{ rg }}"
-      disk_size_gb: 512
-      managed_by: "ocp-cns-{{ item }}"
-    loop: "{{ cns_nodes }}"
-  when: 
-    - deploy_cns | default(true) | bool
-    - not deploy_cns_on_infra | default(false) | bool
 
 - name: Azure | Wait for bastion VM creation
   command: az vm list -g "{{ rg }}" --query "[?provisioningState=='Succeeded'].name" -o tsv

--- a/roles/azure_infra/tasks/bastion.yml
+++ b/roles/azure_infra/tasks/bastion.yml
@@ -8,6 +8,16 @@
     ansible_user: "{{ admin_user }}"
     ansible_become: True
 
+# The Azure VMs are provisioned asynchronously. It can take some time
+# until they are reachable via SSH, even after Azure reports that the
+# provisioning state is "Succeeded".
+- name: Wait for nodes to become reachable via SSH
+  wait_for_connection:
+    sleep: 30
+    timeout: 1200
+    connect_timeout: 10
+  delegate_to: "{{ groups['bastions'][0] }}"
+
 - name: Azure | Bastion RHSM Activation Key
   redhat_subscription:
     state: "{{ state }}"

--- a/roles/azure_infra/templates/hosts.j2
+++ b/roles/azure_infra/templates/hosts.j2
@@ -91,7 +91,7 @@ openshift_portal_net={{ openshift_portal_net }}
 {% endif %}
 
 # Docker
-container_runtime_docker_storage_setup_device=/dev/sdd
+container_runtime_docker_storage_setup_device=/dev/disk/azure/scsi1/lun1
 container_runtime_docker_storage_type=overlay2
 openshift_docker_use_system_container=False
 openshift_use_system_containers=False
@@ -196,11 +196,11 @@ ocp-cns-{{ i }} openshift_schedulable=True openshift_hostname=ocp-cns-{{ i }}
 {% if deploy_cns | default(true) | bool %} 
 {% if not deploy_cns_on_infra | default(false) | bool %}
 {% for i in cns_nodes %}
-ocp-cns-{{ i }}  glusterfs_devices='[ "/dev/sde" ]'
+ocp-cns-{{ i }}  glusterfs_devices='[ "/dev/disk/azure/scsi1/lun2" ]'
 {% endfor %}
 {% else %}
 {% for i in infra_nodes %}
-ocp-infra-{{ i }} glusterfs_devices='[ "/dev/sde" ]'
+ocp-infra-{{ i }} glusterfs_devices='[ "/dev/disk/azure/scsi1/lun2" ]'
 {% endfor %}
 {% endif %}
 {% endif %}

--- a/roles/ocp_pre/tasks/storage_container.yml
+++ b/roles/ocp_pre/tasks/storage_container.yml
@@ -1,7 +1,7 @@
  - name: Create XFS filesystem
    filesystem:
      fstype: xfs
-     dev: /dev/sdc
+     dev: /dev/disk/azure/scsi1/lun0
 
  - name: Set proper permissions on mount point
    file:
@@ -12,11 +12,15 @@
  - name: Restore SELinux context
    command: restorecon -R /var/lib/origin/openshift.local.volumes
    changed_when: False
- 
+
+ - name: Get filesystem UUID
+   command: blkid -sUUID -ovalue /dev/disk/azure/scsi1/lun0
+   register: blkid
+
  - name: Mount XFS filesystem
    mount:
      state: mounted
      path: /var/lib/origin/openshift.local.volumes
-     src: /dev/sdc
+     src: UUID={{ blkid.stdout }}
      fstype: xfs
      opts: gquota

--- a/roles/ocp_pre/tasks/storage_etcd.yml
+++ b/roles/ocp_pre/tasks/storage_etcd.yml
@@ -1,7 +1,7 @@
 - name: Create XFS filesystem
   filesystem:
     fstype: xfs
-    dev: /dev/sde
+    dev: /dev/disk/azure/scsi1/lun2
 
 - name: Set proper permissions on mount point
   file:
@@ -12,9 +12,13 @@
 - name: Restore SELinux context
   command: restorecon -R /var/lib/etcd
 
+- name: Get filesystem UUID
+  command: blkid -sUUID -ovalue /dev/disk/azure/scsi1/lun2
+  register: blkid
+
 - name: Mount XFS filesystem
   mount:
     state: mounted
     path: /var/lib/etcd
-    src: /dev/sde
+    src: UUID={{ blkid.stdout }}
     fstype: xfs


### PR DESCRIPTION
This brings the installation time down to 1 hours, 36 minutes, 20 seconds, saving another 30 minutes compared to the last change.

I've followed https://docs.microsoft.com/en-us/azure/virtual-machines/linux/troubleshoot-device-names-problems to get around the problem we had with disk device names before.

Not using /dev/sdX as the disk device name is important not just during installation, but during every reboot. We had a case where /dev/sdc became /dev/sdh during a reboot - admittedly for a VM that had a couple of PV VHDs attached.