### PR TITLE
Fixing the following issues to support non cns deployments (i.e deploy_cns: False) on v3.10

### DIFF
--- a/roles/azure_infra/templates/hosts.j2
+++ b/roles/azure_infra/templates/hosts.j2
@@ -34,10 +34,10 @@ openshift_hosted_registry_replicas={{ infra_nodes | length }}
 openshift_master_cluster_method=native
 
 openshift_cloudprovider_kind=azure
-{% if sp_app is defined %}
-openshift_cloudprovider_azure_client_id="{{ sp_app.stdout }}"
-{% elif sp_app_id is defined %}
+{% if sp_app_id is defined %}
 openshift_cloudprovider_azure_client_id="{{ sp_app_id }}"
+{% elif sp_app is defined %}
+openshift_cloudprovider_azure_client_id="{{ sp_app.stdout }}"
 {% endif %}
 openshift_cloudprovider_azure_client_secret="{{ sp_secret }}"
 openshift_cloudprovider_azure_tenant_id="{{ tenant_id.stdout }}"
@@ -120,16 +120,6 @@ openshift_enable_service_catalog=true
 osm_project_request_message="{{ osm_project_request_message }}"
 {% endif %}
 
-{% if deploy_cns | default(true) | bool %}
-# CNS Cnfiguration
-# Container image to use for glusterfs pods
-openshift_storage_glusterfs_image="registry.access.redhat.com/rhgs3/rhgs-server-rhel7:v3.10"
-
-# Container image to use for glusterblock-provisioner pod
-openshift_storage_glusterfs_block_image="registry.access.redhat.com/rhgs3/rhgs-gluster-block-prov-rhel7:v3.10"
-
-# Container image to use for heketi pods
-openshift_storage_glusterfs_heketi_image="registry.access.redhat.com/rhgs3/rhgs-volmanager-rhel7:v3.10"
 
 # logging
 {% if deploy_logging | default('True') | bool %}
@@ -137,12 +127,11 @@ openshift_logging_install_logging=True
 openshift_logging_es_pvc_dynamic=true
 openshift_logging_es_pvc_size={{ logging_volume_size }}Gi
 openshift_logging_es_cluster_size={{ infra_nodes|length }}
-openshift_logging_es_pvc_storage_class_name='glusterfs-registry-block'
 openshift_logging_kibana_nodeselector={"node-role.kubernetes.io/infra": "true"}
 openshift_logging_curator_nodeselector={"node-role.kubernetes.io/infra": "true"}
 openshift_logging_es_nodeselector={"node-role.kubernetes.io/infra": "true"}
 {% else %}
-openshift_logging_install_logging=True
+openshift_logging_install_logging=False
 {% endif %}
 
 # metrics
@@ -150,7 +139,6 @@ openshift_logging_install_logging=True
 openshift_metrics_install_metrics=True
 openshift_metrics_storage_kind=dynamic
 openshift_metrics_storage_volume_size={{ metrics_volume_size }}Gi
-openshift_metrics_cassandra_pvc_storage_class_name='glusterfs-registry-block'
 openshift_metrics_hawkular_nodeselector={"node-role.kubernetes.io/infra": "true"}
 openshift_metrics_cassandra_nodeselector={"node-role.kubernetes.io/infra": "true"}
 openshift_metrics_heapster_nodeselector={"node-role.kubernetes.io/infra": "true"}
@@ -164,22 +152,51 @@ openshift_hosted_prometheus_deploy=True
 openshift_prometheus_storage_kind=dynamic
 openshift_prometheus_storage_type=pvc
 openshift_prometheus_storage_volume_size={{ prometheus_volume_size | default('25Gi') }}Gi
-openshift_prometheus_storage_class='glusterfs-registry-block'
 {% else %}
 openshift_hosted_prometheus_deploy=False
 {% endif %}
 
 # grafana
-{% if deploy_grafan | default(true) | bool %}
+{% if deploy_grafana | default(true) | bool %}
 openshift_grafana_state=present
 openshift_grafana_node_exporter=true
 openshift_grafana_storage_type=pvc
-openshift_grafana_storage_class='glusterfs-registry-block'
 openshift_grafana_prometheus_namespace='openshift-metrics'
 openshift_grafana_prometheus_serviceaccount='prometheus'
 openshift_grafana_prometheus_route='prometheus'
 {% else %}
 openshift_grafana_state=absent
+{% endif %}
+
+{% if deploy_cns | default(true) | bool %}
+# CNS Cnfiguration
+# Container image to use for glusterfs pods
+openshift_storage_glusterfs_image="registry.access.redhat.com/rhgs3/rhgs-server-rhel7:v3.10"
+
+# Container image to use for glusterblock-provisioner pod
+openshift_storage_glusterfs_block_image="registry.access.redhat.com/rhgs3/rhgs-gluster-block-prov-rhel7:v3.10"
+
+# Container image to use for heketi pods
+openshift_storage_glusterfs_heketi_image="registry.access.redhat.com/rhgs3/rhgs-volmanager-rhel7:v3.10"
+
+# logging
+{% if deploy_logging | default('True') | bool %}
+openshift_logging_es_pvc_storage_class_name='glusterfs-registry-block'
+{% endif %}
+
+# metrics
+{% if deploy_metrics | default('True') | bool %}
+openshift_metrics_cassandra_pvc_storage_class_name='glusterfs-registry-block'
+{% endif %}
+
+# prometheus
+{% if deploy_prometheus | default(True) | bool %}
+openshift_prometheus_storage_class='glusterfs-registry-block'
+{% endif %}
+
+# grafana
+{% if deploy_grafana | default(true) | bool %}
+openshift_grafana_storage_class='glusterfs-registry-block'
 {% endif %}
 
 # Cluster 1
@@ -217,6 +234,25 @@ openshift_storageclass_name=azure-storage
 openshift_storageclass_provisioner=azure-disk
 openshift_storageclass_parameters={'storageaccounttype': 'Standard_LRS', 'kind': 'managed'}
 openshift_storageclass_default=true
+# logging
+{% if deploy_logging | default('True') | bool %}
+openshift_logging_es_pvc_storage_class_name='azure-storage'
+{% endif %}
+
+# metrics
+{% if deploy_metrics | default('True') | bool %}
+openshift_metrics_cassandra_pvc_storage_class_name='azure-storage'
+{% endif %}
+
+# prometheus
+{% if deploy_prometheus | default(True) | bool %}
+openshift_prometheus_storage_class='azure-storage'
+{% endif %}
+
+# grafana
+{% if deploy_grafana | default(true) | bool %}
+openshift_grafana_storage_class='azure-storage'
+{% endif %}
 {% endif %}
 
 # Setup azure blob registry storage
@@ -244,13 +280,13 @@ ocp-master-{{ i }}
 
 [nodes]
 {% for i in master_nodes %}
-ocp-master-{{ i }} openshift_node_group_name='node-config-master' openshift_schedulable=true
+ocp-master-{{ i }} openshift_node_group_name='node-config-master' openshift_schedulable=true openshift_hostname=ocp-master-{{ i }} openshift_node_labels="{'region': 'master'}"
 {% endfor %}
 {% for i in infra_nodes %}
-ocp-infra-{{ i }}  openshift_node_group_name='node-config-infra'
+ocp-infra-{{ i }}  openshift_node_group_name='node-config-infra' openshift_hostname=ocp-infra-{{ i }} openshift_node_labels="{'region': 'infra'}"
 {% endfor %}
 {% for i in app_nodes %}
-ocp-app-{{ i }}    openshift_node_group_name='node-config-compute'
+ocp-app-{{ i }}    openshift_node_group_name='node-config-compute' openshift_hostname=ocp-app-{{ i }} openshift_node_labels="{'region': 'apps'}"
 {% endfor %}
 
 {% if deploy_cns | default(true) | bool  and deploy_cns is defined %}
@@ -261,7 +297,7 @@ ocp-infra-{{ i }} glusterfs_zone={{ i }}  glusterfs_devices='[ "/dev/disk/azure/
 {% endfor %}
 
 [glusterfs]
-{% for i in infra_nodes %}
+{% for i in app_nodes %}
 ocp-app-{{ i }} glusterfs_zone={{ i }} glusterfs_devices='[ "/dev/disk/azure/scsi1/lun2" ]'
 {% endfor %}
 {% else %}
@@ -271,4 +307,7 @@ ocp-app-{{ i }} glusterfs_zone={{ i }} glusterfs_devices='[ "/dev/disk/azure/scs
 ocp-infra-{{ i }}  glusterfs_zone={{ i }} glusterfs_devices='[ "/dev/disk/azure/scsi1/lun2" ]'
 {% endfor %}
 {% endif %}
+{% else %}
+[glusterfs]
+[glusterfs_registry]
 {% endif %}

--- a/vars.yml.example
+++ b/vars.yml.example
@@ -88,7 +88,7 @@ vnet_cidr: "192.168.0.0/16"
 master_subnet_cidr: "192.168.0.0/27"
 infra_subnet_cidr: "192.168.0.32/27"
 cns_subnet_cidr: "192.168.0.64/27"
-app_subnet_cidr: "192.168.0.128/25"
+app_subnet_cidr: "192.168.0.128/27"
 
 api_port: 443
 
@@ -189,6 +189,7 @@ deploy_cns: true
 deploy_metrics: true
 deploy_logging: true
 deploy_prometheus: true
+deploy_grafana: true
 
 # volume sizing defaults
 metrics_volume_size: 25


### PR DESCRIPTION
1. hosts.j2 to define variables related to logging, metrics, grafana
    when deploy_cns is False

2. If sp_app_id is defined in vars.yml, sp_app variable will not be populated
    when executing the task azure_infra/tasks/cloudprovider.yml. Hence
    adding the sp_app_id check before checking for sp_app in hosts.j2

3. Define sections for glusterfs, glusterfs_registry even when
    deploy_cns is False. This is because we check for
    'inventory_hostname in groups.glusterfs' while registering the
    nodes to RHSM in roles/ocp_pre/tasks/subscribe.yml

4. Fixing the typos in vars.yml.example
    - define deploy_grafana which will be used in hosts.j2
    - modified app_subnet_cidr: "192.168.0.128/25" to
    app_subnet_cidr: "192.168.0.128/27"

5. renamed vars deploy_grafan to deploy_grafana

Signed-off-by: shwethahp <spandura@redhat.com>